### PR TITLE
서버 타입 / 쿼리 수정 후 클라이언트 변경

### DIFF
--- a/agaein_server/graphql/resolvers/article/mutations.ts
+++ b/agaein_server/graphql/resolvers/article/mutations.ts
@@ -89,11 +89,11 @@ const articleMutations = {
                             age,
                         },
                         REVIEW: {
+                            articleId: article.id,
                             title,
                             content,
                         },
                     };
-
                     return knex(boardType)
                         .transacting(trx)
                         .insert(articleDetailForm[boardType])

--- a/agaein_server/graphql/resolvers/index.ts
+++ b/agaein_server/graphql/resolvers/index.ts
@@ -6,11 +6,8 @@ import { articleQueries, articleMutations } from './article';
 const resolvers = {
     Upload: GraphQLUpload,
     ArticleDetail: {
-        __resolveType(_: any, args: any) {
-            if (args.gratuity) {
-                return 'LFP';
-            }
-            return 'LFG';
+        __resolveType(obj: any) {
+            return obj.articleType;
         },
     },
     Query: {

--- a/agaein_server/graphql/typedefs/Article.graphql
+++ b/agaein_server/graphql/typedefs/Article.graphql
@@ -12,6 +12,7 @@ type Location {
 }
 
 type LFG {
+    id: ID!
     type: BREED_TYPE!
     breed: String!
     name: String!
@@ -25,12 +26,13 @@ type LFG {
 }
 
 type LFP {
+    id: ID!
     type: BREED_TYPE!
     breed: String!
     name: String!
     feature: String!
     gender: String!
-    gratuity: Int!
+    gratuity: Int
     age: Int!
     password: String
     alarm: Boolean!
@@ -39,7 +41,7 @@ type LFP {
 }
 
 type REVIEW {
-    # 더 넣을 것 생각
+    id: ID!
     title: String
     content: String
 }
@@ -47,7 +49,7 @@ type REVIEW {
 union ArticleDetail = LFG | LFP | REVIEW
 
 type Article {
-    id: Int!
+    id: ID!
     images: [String]!
     view: Int!
     type: BOARD_TYPE!
@@ -78,4 +80,5 @@ input articleDetailInput {
     lostDate: Date
     gratuity: Int
     title: String
+    content: String
 }

--- a/agaein_web/src/graphql/queries/Article.fragment.graphql
+++ b/agaein_web/src/graphql/queries/Article.fragment.graphql
@@ -1,19 +1,33 @@
-fragment ArticleCommon on Article {
+fragment ArticleFragment on Article {
     id
-    comments {
-        ...CommentFragment
-    }
     createdAt
     updatedAt
     images
     type
     view
+    comments {
+        ...CommentFragment
+    }
     author {
         ...UserFragment
+    }
+    articleDetail {
+        ... on LFG {
+            ...LFGDetail
+        }
+
+        ... on LFP {
+            ...LFPDetail
+        }
+
+        ... on REVIEW {
+            ...ReviewDetail
+        }
     }
 }
 
 fragment LFGDetail on LFG {
+    id
     type
     breed
     name
@@ -30,6 +44,7 @@ fragment LFGDetail on LFG {
     }
 }
 fragment LFPDetail on LFP {
+    id
     type
     breed
     name
@@ -46,6 +61,7 @@ fragment LFPDetail on LFP {
     }
 }
 fragment ReviewDetail on REVIEW {
+    id
     title
     content
 }

--- a/agaein_web/src/graphql/queries/Article.graphql
+++ b/agaein_web/src/graphql/queries/Article.graphql
@@ -1,43 +1,17 @@
 query getArticles($boardType: BOARD_TYPE!) {
     articles(boardType: $boardType) {
-        ...ArticleCommon
-        articleDetail {
-            ... on LFG {
-                ...LFGDetail
-            }
-
-            ... on LFP {
-                ...LFPDetail
-            }
-
-            ... on REVIEW {
-                ...ReviewDetail
-            }
-        }
+        ...ArticleFragment
     }
 }
 
 query getArticle($id: ID!) {
     article(id: $id) {
-        ...ArticleCommon
-        articleDetail {
-            ... on LFG {
-                ...LFGDetail
-            }
-
-            ... on LFP {
-                ...LFPDetail
-            }
-
-            ... on REVIEW {
-                ...ReviewDetail
-            }
-        }
+        ...ArticleFragment
     }
 }
 
 mutation createArticle($boardType: BOARD_TYPE!, $files: [Upload]!, $articleDetail: articleDetailInput!) {
     createArticle(boardType: $boardType, files: $files, articleDetail: $articleDetail) {
-        ...ArticleCommon
+        ...ArticleFragment
     }
 }

--- a/agaein_web/src/hooks/useBookmark.ts
+++ b/agaein_web/src/hooks/useBookmark.ts
@@ -2,14 +2,14 @@ import { useEffect, useState } from 'react';
 import useLocalStorage from './useLocalStorage';
 
 const useBookmark = () => {
-    const [storedValue, setValue] = useLocalStorage('bookmark', [1]);
-    const [bookmarks, setBookmarks] = useState<number[]>([]);
+    const [storedValue, setValue] = useLocalStorage('bookmark', ['1']);
+    const [bookmarks, setBookmarks] = useState<string[]>([]);
 
     useEffect(() => {
         setBookmarks(storedValue || []);
     }, []);
 
-    const getTargetBookmarks = (article_id: number) => {
+    const getTargetBookmarks = (article_id: string) => {
         const isExist = !!bookmarks.find((bookmark) => bookmark === article_id);
         if (isExist) {
             return bookmarks.filter((bookmark) => bookmark !== article_id);
@@ -17,13 +17,13 @@ const useBookmark = () => {
         return [article_id, ...bookmarks];
     };
 
-    const setBookmark = (article_id: number) => {
+    const setBookmark = (article_id: string) => {
         const target = getTargetBookmarks(article_id);
         setValue(target);
         setBookmarks(target);
     };
 
-    const isBookmarked = (article_id: number) => {
+    const isBookmarked = (article_id: string) => {
         return !!bookmarks.find((bookmark) => bookmark === article_id);
     };
 


### PR DESCRIPTION
쿼리에 문제가 있어 수정을 좀 했습니다. 

## 작업 내용
* 루트쿼리가 정의된 부분이 예전 방식대로 되어 있었던 부분 수정 (resolvers/index.ts)
* Review 타입에서 breed를 join하는 부분 에러 - 일단은 분기하도록 변경
* articleDetail에 Join한 모든 데이터가 다 내려가고 있던 부분 (type이 겹칩니다 ex. DOG/CAT 이랑 LFP,LFG 같은게 겹침)
## 참고 사항
* articleDetail 세부 타입에 각각 id를 넣은것은 Apollo Client 캐시 데이터 생성 정책때문입니다.
<img width="798" alt="스크린샷 2021-11-02 오전 8 46 45" src="https://user-images.githubusercontent.com/18079523/139756790-8ed5bcd7-949f-4fe1-a6d0-c8b1406d6bec.png">
* 일단 클라이언트의 쿼리가 돌아가도록 변경한 것이라 코드가 좀 더러워졌습니다. 
* 차후에 리팩토링이 필요해보입니다..!