### PR TITLE
홈화면, 게시글 상세화면 - 서버데이터 적용

### DIFF
--- a/agaein_server/graphql/resolvers/article/queries.ts
+++ b/agaein_server/graphql/resolvers/article/queries.ts
@@ -3,12 +3,21 @@ import { knex } from '../../database';
 
 const articleQueries = {
     articles: async (_: any, args: any) => {
-        const { boardType } = args;
+        const { boardType, limit = 6, offset = 0 } = args;
         try {
             const articleDetails =
                 boardType === 'REVIEW'
                     ? await knex(`${boardType}`)
-                    : await knex(`${boardType}`).join('breed', `${args.boardType}.breed_id`, 'breed.id');
+                          .join('article', 'article.id', '=', `${boardType}.article_id`)
+                          .orderBy('created_at', 'desc')
+                          .limit(limit)
+                          .offset(offset)
+                    : await knex(`${boardType}`)
+                          .join('article', 'article.id', '=', `${boardType}.article_id`)
+                          .join('breed', `${boardType}.breed_id`, 'breed.id')
+                          .orderBy('created_at', 'desc')
+                          .limit(limit)
+                          .offset(offset);
 
             const articles = articleDetails.map((detail: any) => {
                 const { articleId, breedId, ...detailData } = detail;

--- a/agaein_server/graphql/typedefs/Article.graphql
+++ b/agaein_server/graphql/typedefs/Article.graphql
@@ -8,6 +8,7 @@ type Location {
     lat: Float!
     lng: Float!
     address: String!
+    roadAddress: String
     detail: String
 }
 
@@ -64,6 +65,7 @@ input LocationInput {
     lat: Float!
     lng: Float!
     address: String!
+    roadAddress: String
     detail: String
 }
 

--- a/agaein_server/graphql/typedefs/index.graphql
+++ b/agaein_server/graphql/typedefs/index.graphql
@@ -13,7 +13,7 @@ type Query {
     user(id: ID!): User
     me: User!
     # Article
-    articles(boardType: BOARD_TYPE!): [Article]!
+    articles(boardType: BOARD_TYPE!, offset: Int, limit: Int): [Article]!
     article(id: ID!): Article
     # Breed
     breeds(type: BREED_TYPE!): [Breed]!
@@ -24,17 +24,13 @@ type Mutation {
     # User
     login(kakaoId: String!): Login!
     # Article
-    createArticle(
-        boardType: BOARD_TYPE!
-        files: [Upload]!
-        articleDetail: articleDetailInput!
-    ): Article!
+    createArticle(boardType: BOARD_TYPE!, files: [Upload]!, articleDetail: articleDetailInput!): Article!
     deleteArticle(id: ID!, password: String): ID!
     createComment(articleId: ID!, commentId: ID, content: String!, password: String): Comment!
     deleteComment(id: ID!, password: String): ID!
     # Breed
     createBreed(type: BREED_TYPE!, breed: String!): Breed!
-    deleteBreed(id:ID!): ID!
+    deleteBreed(id: ID!): ID!
     # Bookmark
     createBookmark(articleId: ID!): Bookmark!
     deleteBookmark(id: ID!): ID!

--- a/agaein_web/src/components/molecules/BookMark/BookMark.style.ts
+++ b/agaein_web/src/components/molecules/BookMark/BookMark.style.ts
@@ -1,17 +1,19 @@
-import { BookmarkIcon as SolidBookMark } from '@heroicons/react/solid';
-import { BookmarkIcon as OutlineBookMark } from '@heroicons/react/outline';
+import { BookmarkIcon } from '@heroicons/react/solid';
 import styled from 'styled-components';
 
-export const BookMarkActive = styled(SolidBookMark)`
+export const BookMarkActive = styled(BookmarkIcon)`
     color: ${(props) => props.theme.light.sub1};
-    width: 18px;
-    height: 18px;
+    width: 19px;
+    height: 24px;
 `;
 
-export const BookMarkInActive = styled(OutlineBookMark)`
-    color: white;
-    width: 18px;
-    height: 18px;
+export const BookMarkInActive = styled(BookmarkIcon)`
+    color: ${(props) => props.theme.light.DarkGrey1};
+    width: 19px;
+    height: 24px;
 `;
 
-export const BookMarkContainer = styled.button``;
+export const BookMarkContainer = styled.button`
+    width: 24px;
+    height: 24px;
+`;

--- a/agaein_web/src/components/molecules/NavBar/NavBar.tsx
+++ b/agaein_web/src/components/molecules/NavBar/NavBar.tsx
@@ -14,7 +14,7 @@ interface KaKaoLoginResult {
 }
 
 const NavBar = () => {
-    const { isLoggedIn, login, user } = useContext(UserContext);
+    const { isLoggedIn, login, user, signOut } = useContext(UserContext);
     const onLoginComplete = (result: KaKaoLoginResult) => {
         login(result.response.access_token, String(result.profile.id));
     };
@@ -30,7 +30,7 @@ const NavBar = () => {
                 </Title>
             </Link>
             {isLoggedIn ? (
-                <UserTag>
+                <UserTag onClick={signOut}>
                     <Font label={user.nickname ?? '회원'} fontType="subhead" htmlElement="span" />
                     <ChevronDown />
                 </UserTag>

--- a/agaein_web/src/components/molecules/PostItemBox/PostItemBox.style.ts
+++ b/agaein_web/src/components/molecules/PostItemBox/PostItemBox.style.ts
@@ -34,10 +34,10 @@ export const InfoItem = styled.li`
 
 export const InfoCategory = styled.em`
     display: table-cell;
-    padding: 0 10px;
+    padding: 0 10px 0 0;
     font-size: 12px;
     font-weight: 600;
-    color: ${(props) => props.theme.light.primary};
+    color: ${(props) => props.theme.light.DarkGrey2};
 `;
 
 export const InfoText = styled.span`
@@ -56,6 +56,6 @@ export const ContentTag = styled.div`
 
 export const BookMarkBox = styled.div`
     position: absolute;
-    top: 5px;
-    right: 5px;
+    top: 6px;
+    right: 6px;
 `;

--- a/agaein_web/src/components/molecules/PostItemBox/PostItemBox.tsx
+++ b/agaein_web/src/components/molecules/PostItemBox/PostItemBox.tsx
@@ -24,8 +24,18 @@ interface PostItemProps {
 
 const PostItem = (props: PostItemProps) => {
     const { item, bookmarked = false, setBookmark = () => {} } = props;
-    const { id, articleDetail, createdAt } = item;
-    const { breed, gender, location, age } = articleDetail as Lfg;
+    const { id, articleDetail, createdAt, images } = item;
+    const { breed, type, gender, location, age } = articleDetail as Lfg;
+
+    function typeToKr() {
+        if (type === 'DOG') {
+            return '개';
+        }
+        if (type === 'CAT') {
+            return '고양이';
+        }
+        return '기타';
+    }
 
     return (
         <>
@@ -35,12 +45,12 @@ const PostItem = (props: PostItemProps) => {
                         <BookMark active={bookmarked} onClick={setBookmark} />
                     </BookMarkBox>
                     <Thumb>
-                        <Img src={penguin} alt="실종 동물" />
+                        <Img src={images.length === 0 ? penguin : (images[0] as string)} alt="실종 동물" />
                     </Thumb>
                     <InfoList>
                         <InfoItem>
                             <InfoCategory>품종</InfoCategory>
-                            <InfoText>{breed}</InfoText>
+                            <InfoText>{`${typeToKr()} | ${breed}`}</InfoText>
                         </InfoItem>
                         <InfoItem>
                             <InfoCategory>실종일</InfoCategory>
@@ -48,7 +58,6 @@ const PostItem = (props: PostItemProps) => {
                         </InfoItem>
                         <InfoItem>
                             <InfoCategory>지역</InfoCategory>
-                            {/* TODO : 글자수 넘어가는 부분 처리 */}
                             <InfoText>{location.address.substr(0, 9)}</InfoText>
                         </InfoItem>
                     </InfoList>

--- a/agaein_web/src/components/organism/HomeArticleList/HomeArticleList.tsx
+++ b/agaein_web/src/components/organism/HomeArticleList/HomeArticleList.tsx
@@ -23,7 +23,6 @@ const HomeArticleList = ({ boardType }: HomeArticleListProps) => {
             boardType,
         },
     });
-
     const getTitle = (boardType: Board_Type) => {
         switch (boardType) {
             case Board_Type.Lfg:
@@ -40,6 +39,9 @@ const HomeArticleList = ({ boardType }: HomeArticleListProps) => {
     const isEmpty = (items?: Array<Article>) => {
         if (!items) return true;
         return items.length === 0;
+    };
+    const isReviewType = () => {
+        return boardType === Board_Type.Review;
     };
 
     if (loading) return <p>Loading</p>;
@@ -63,14 +65,14 @@ const HomeArticleList = ({ boardType }: HomeArticleListProps) => {
                     <p>등록된 게시글이 없습니다</p>
                 ) : (
                     articles?.map((article) => {
-                        return boardType === Board_Type.Review ? (
-                            <ReviewWrapper>
+                        return isReviewType() ? (
+                            <ReviewWrapper key={article.id}>
                                 <ReviewItem item={article} />
                             </ReviewWrapper>
                         ) : (
-                            <ListItem key={article?.id}>
+                            <ListItem key={article.id}>
                                 <PostItem
-                                    item={article as Article}
+                                    item={article}
                                     bookmarked={isBookmarked(article.id)}
                                     setBookmark={() => setBookmark(article.id)}
                                 />

--- a/agaein_web/src/components/pages/article/articleDetail/ArticleDetail.style.ts
+++ b/agaein_web/src/components/pages/article/articleDetail/ArticleDetail.style.ts
@@ -16,7 +16,13 @@ export const ArticleDetailContainer = styled.div`
 `;
 
 export const TitleAndBookMarkContainer = styled.div`
-    display: inline-block;
+    display: flex;
+    position: relative;
+`;
+export const BookmarkContainer = styled.div`
+    position: absolute;
+    top: 5;
+    right: 5;
 `;
 
 export const ArticleDetailDetailContainer = styled.div`
@@ -33,6 +39,8 @@ export const ArticleDetailDetailContainer = styled.div`
 export const ArticleDetailContentContainer = styled.div`
     margin: 20px auto;
     width: 620px;
+    overflow: hidden;
+    width: auto;
 `;
 export const ArticleInfoContainer = styled.div`
     display: flex;

--- a/agaein_web/src/components/pages/article/articleDetail/ArticleDetail.tsx
+++ b/agaein_web/src/components/pages/article/articleDetail/ArticleDetail.tsx
@@ -22,10 +22,11 @@ import ReactKaKaoMap from 'components/organism/ReactKakaoMap/ReactKakaoMap';
 import { convertDate, YYYYMMDD } from 'utils/date';
 import { Fragment } from 'react';
 import { isArticle, isLFP } from 'utils/typeGuards';
+import penguin from 'assets/image/penguin.png';
 
 const ArticleDetail = ({ match }: RouteComponentProps<ArticleDetailParams>) => {
     const { isBookmarked, setBookmark } = useBookmark();
-    const [isOpenModal, setIsOpenModal] = useState<boolean>(false);
+    const [isOpenModal, setIsOpenModal] = useState(false);
     const { data, error, loading } = useGetArticleQuery({
         variables: {
             id: match.params.id,
@@ -35,7 +36,7 @@ const ArticleDetail = ({ match }: RouteComponentProps<ArticleDetailParams>) => {
     if (loading) return <p>Loading...</p>;
     if (error) return <p>Error occur</p>;
     if (data === undefined || !isArticle(data.article)) return <p>No data</p>;
-    const { id, createdAt, articleDetail, view, author, comments = [] } = data.article;
+    const { id, createdAt, articleDetail, view, author, comments = [], images = [] } = data.article;
 
     // ? TypeGuard로 해결할 방법을 모르겠음
     const { breed, feature, age = '??', gender, name, location, foundDate, lostDate } = articleDetail as any;
@@ -57,13 +58,20 @@ const ArticleDetail = ({ match }: RouteComponentProps<ArticleDetailParams>) => {
     const closeModal = () => {
         setIsOpenModal(false);
     };
+    const targetImages = () => {
+        if (images.length === 0) {
+            return [penguin];
+        }
+        return images;
+    };
+
     return (
         <Fragment>
             <HorizontalContainer>
-                <ImageCarousel images={imgDummy} />
+                <ImageCarousel images={targetImages() as string[]} />
                 <ArticleDetailContainer>
                     <Chip label="진행중" />
-                    <Chip label="사례금 200,000원" />
+
                     <ArticleDetailContentContainer>
                         <TitleAndBookMarkContainer>
                             <Font label={getTitle()} fontType="h4" fontWeight="bold" htmlElement="span" />
@@ -96,9 +104,3 @@ const ArticleDetail = ({ match }: RouteComponentProps<ArticleDetailParams>) => {
 };
 
 export default ArticleDetail;
-
-const imgDummy = [
-    'https://health.chosun.com/site/data/img_dir/2021/07/26/2021072601445_0.jpg',
-    'https://cdn.mkhealth.co.kr/news/photo/202102/52163_52859_5928.jpg',
-    'https://images.mypetlife.co.kr/content/uploads/2019/09/09153001/dog-panting-1024x683.jpg',
-];

--- a/agaein_web/src/graphql/apollo.ts
+++ b/agaein_web/src/graphql/apollo.ts
@@ -15,7 +15,7 @@ const uploadLink = createUploadLink({
 });
 
 const authLink = setContext((_, { headers }) => {
-    const accessToken = cookies.get('accessToken') || '';
+    const accessToken = cookies.get('accessToken') ?? '';
     return {
         headers: {
             ...headers,
@@ -36,7 +36,7 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
 export const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({
     name: 'agaein',
     version: '0.0.1',
-    link: from([authLink, errorLink, httpLink, uploadLink]),
+    link: from([authLink, errorLink, uploadLink, httpLink]),
     cache: new InMemoryCache({
         addTypename: true,
         resultCaching: true,

--- a/agaein_web/src/graphql/queries/Article.graphql
+++ b/agaein_web/src/graphql/queries/Article.graphql
@@ -1,5 +1,5 @@
-query getArticles($boardType: BOARD_TYPE!) {
-    articles(boardType: $boardType) {
+query getArticles($boardType: BOARD_TYPE!, $limit: Int, $offset: Int) {
+    articles(boardType: $boardType, limit: $limit, offset: $offset) {
         id
         images
         articleDetail {

--- a/agaein_web/src/utils/date.ts
+++ b/agaein_web/src/utils/date.ts
@@ -20,9 +20,9 @@ const isSameYear = (year1: number, year2: number): boolean => {
  * 오늘 작성된 글 : 시간만 표기
  * 올해지만 오늘은 아님 : 월, 일만 표기
  * 올해가 아님 : 연, 월, 일 표기
- * @param {string} date
+ * @param {string} date\
  */
-export const convertDate = (date: string): string => {
+const convertDate = (date: string): string => {
     const now = moment(new Date());
     const targetDate = moment(date);
 
@@ -37,6 +37,8 @@ export const convertDate = (date: string): string => {
     return targetDate.format('YY년 MM월 DD일');
 };
 
-export const YYYYMMDD = (date: string) => {
+const YYYYMMDD = (date: string) => {
     return moment(date).format('YYYY년 MM월 DD일');
 };
+
+export { convertDate, YYYYMMDD };

--- a/agaein_web/src/utils/typeGuards.ts
+++ b/agaein_web/src/utils/typeGuards.ts
@@ -1,4 +1,4 @@
-import { Article, Bookmark, Comment, Lfg, Lfp, Review } from 'graphql/generated/generated';
+import { Article, Bookmark, Comment, File, Lfg, Lfp, Review } from 'graphql/generated/generated';
 
 // TODO : Type Guard의 조건을 더 엄밀하게 정의해야함
 
@@ -20,5 +20,8 @@ function isReview(target: unknown): target is Review {
 function isBookmark(target: unknown): target is Bookmark {
     return (target as Bookmark).__typename === 'Bookmark' && (target as Bookmark).articleId !== null;
 }
+function isComments(target: unknown[]) {
+    return (target as Comment[]).some((comment) => isComment(comment));
+}
 
-export { isArticle, isComment, isLFP, isLFG, isReview, isBookmark };
+export { isArticle, isComment, isLFP, isLFG, isReview, isBookmark, isComments };


### PR DESCRIPTION
홈화면과 게시글 상세화면에 서버데이터 붙히는 작업
mutation cache 및 articleList 페이지 테스트를 위한 간단한 페이지네이션 구현

## 작업 내용
* 홈화면, 게시글 상세화면 더미데이터 제거
* articles 쿼리 최신 순서대로 불러오도록 변경
* articles 쿼리에 offset기반 간단한 페이지네이션 추가(테스트용)

## 참고 사항
location input에 roadAddress 추가되었습니다.