### PR TITLE
report & comment update 작성 및 updateArticle 개선

### DIFF
--- a/agaein_server/graphql/resolvers/article/mutations.ts
+++ b/agaein_server/graphql/resolvers/article/mutations.ts
@@ -138,13 +138,7 @@ const articleMutations = {
                                     url: 'https://www.agaein.com/file/image/' + filename,
                                 };
 
-                                await knex('image')
-                                    .transacting(trx)
-                                    .insert(imageForm)
-                                    .returning('*')
-                                    .then((image: any) => {
-                                        article.images.push(image[0]);
-                                    });
+                                await knex('image').transacting(trx).insert(imageForm);
 
                                 const out = require('fs').createWriteStream('image/' + filename);
                                 await stream.pipe(out);
@@ -272,13 +266,7 @@ const articleMutations = {
                                         url: 'https://www.agaein.com/file/image/' + filename,
                                     };
 
-                                    knex('image')
-                                        .transacting(trx)
-                                        .insert(imageForm)
-                                        .returning('*')
-                                        .then((image: any) => {
-                                            article.images.push(image[0]);
-                                        });
+                                    await knex('image').transacting(trx).insert(imageForm);
 
                                     const out = require('fs').createWriteStream('image/' + filename);
                                     await stream.pipe(out);

--- a/agaein_server/graphql/resolvers/article/mutations.ts
+++ b/agaein_server/graphql/resolvers/article/mutations.ts
@@ -172,7 +172,7 @@ const articleMutations = {
         });
     },
     updateArticle: async (_: any, args: any, context: any) => {
-        const { articleId, articleDetail } = args;
+        const { id, articleDetail } = args;
         const { password, keyword } = articleDetail;
 
         // @TODO validation 확인해야 됨.
@@ -188,24 +188,26 @@ const articleMutations = {
         };
 
         if (password) {
-            const articlePassword = await knex('article').where('id', articleId).first('password');
+            const articlePassword = await knex('article').where('id', id).first('password');
             if (password !== articlePassword.password) {
                 throw new ApolloError('Invaild Password', 'UNAUTHENTICATED');
             }
         } else if (context.req.headers.authorization && context.req.headers.authorization.split(' ')[1]) {
             const jwtToken = readAccessToken(context.req.headers.authorization.split(' ')[1]);
-            const articleUser = await knex('article').where('id', articleId).first('userId');
+            const articleUser = await knex('article').where('id', id).first('userId');
             if (articleUser.userId !== (<any>jwtToken).userId) {
                 throw new ApolloError('Invaild AccessToken', 'UNAUTHENTICATED');
             }
             article.userId = articleUser.userId;
+        } else {
+            throw new ApolloError('Must Need AccessToken or Password', 'UNAUTHENTICATED');
         }
 
         return await knex.transaction(async (trx: any) => {
             return await knex('article')
                 .transacting(trx)
                 .update(articleForm)
-                .where('id', articleId)
+                .where('id', id)
                 .returning('*')
                 .then(async (updatedArticle: any) => {
                     article.id = updatedArticle[0].id;
@@ -226,7 +228,7 @@ const articleMutations = {
                     return await knex(boardType)
                         .transacting(trx)
                         .update(articleDetailForm)
-                        .where('article_id', articleId)
+                        .where('article_id', id)
                         .returning('*')
                         .then(async (updatedArticleDetail: any) => {
                             article.articleDetail = updatedArticleDetail[0];
@@ -303,6 +305,40 @@ const articleMutations = {
                     throw new ApolloError('DataBase Server Error', 'INTERNAL_SERVER_ERROR');
                 });
         });
+    },
+    updateComment: async (_: any, args: any, context: any) => {
+        const now = new Date();
+        const { id, content, password } = args;
+        const commentForm = {
+            content,
+            updatedAt: now,
+        };
+
+        if (password) {
+            const commentPassword = await knex('comment').where('id', id).first('password');
+            if (password !== commentPassword.password) {
+                throw new ApolloError('Invaild Password', 'UNAUTHENTICATED');
+            }
+        } else if (context.req.headers.authorization && context.req.headers.authorization.split(' ')[1]) {
+            const jwtToken = readAccessToken(context.req.headers.authorization.split(' ')[1]);
+            const commentUser = await knex('comment').where('id', id).first('userId');
+            if (commentUser.userId !== (<any>jwtToken).userId) {
+                throw new ApolloError('Invaild AccessToken', 'UNAUTHENTICATED');
+            }
+        } else {
+            throw new ApolloError('Must Need AccessToken or Password', 'UNAUTHENTICATED');
+        }
+
+        try {
+            const comments = await knex('comment').update(commentForm).where('id', id).returning('*');
+            const comment = comments[0];
+            return comment;
+        } catch {
+            console.error('createComment에서 에러발생');
+            console.trace();
+
+            throw new ApolloError('DataBase Server Error', 'INTERNAL_SERVER_ERROR');
+        }
     },
     createComment: async (_: any, args: any, context: any) => {
         const now = new Date();

--- a/agaein_server/graphql/resolvers/article/queries.ts
+++ b/agaein_server/graphql/resolvers/article/queries.ts
@@ -15,6 +15,7 @@ const articleQueries = {
                     : await knex(`${boardType}`)
                           .join('article', 'article.id', `${boardType}.article_id`)
                           .join('breed', `${boardType}.breed_id`, 'breed.id')
+                          .select('*', `${boardType}.id as id`)
                           .orderBy('created_at', 'desc')
                           .limit(limit)
                           .offset(offset);

--- a/agaein_server/graphql/resolvers/report/mutations.ts
+++ b/agaein_server/graphql/resolvers/report/mutations.ts
@@ -11,6 +11,7 @@ const reportMutations = {
         report.createdAt = now;
         report.updatedAt = now;
 
+        // @TODO 패스워드가 없으면 바로 생성이나 수정인데, 피그마 상에는 패스워드가 없었음. 이 부분 무조건 회원만 가능한건가?
         if (context.req.headers.authorization && context.req.headers.authorization.split(' ')[1]) {
             const jwtToken = readAccessToken(context.req.headers.authorization.split(' ')[1]);
             report.userId = (<any>jwtToken).userId;
@@ -51,6 +52,73 @@ const reportMutations = {
                             console.log(`store ${filename}`);
                         });
                     });
+                })
+                .then(() => {
+                    return reportResponse;
+                })
+                .catch(() => {
+                    console.error('createReport에서 에러발생');
+                    console.trace();
+
+                    throw new ApolloError('DataBase Server Error', 'INTERNAL_SERVER_ERROR');
+                });
+        });
+    },
+    updateReport: async (_: any, args: any, context: any) => {
+        const { id, files, report } = args;
+
+        let reportResponse: any = {};
+        const now = new Date();
+        report.updatedAt = now;
+        console.log(report);
+
+        // @TODO 패스워드가 없으면 바로 생성이나 수정인데, 피그마 상에는 패스워드가 없었음. 이 부분 무조건 회원만 가능한건가?
+        if (context.req.headers.authorization && context.req.headers.authorization.split(' ')[1]) {
+            const reportUser = await knex('report').where('id', id).first('user_id');
+            const jwtToken = readAccessToken(context.req.headers.authorization.split(' ')[1]);
+            if (reportUser.userId !== (<any>jwtToken).userId) {
+                throw new ApolloError('Invaild AccessToken', 'UNAUTHENTICATED');
+            }
+        }
+
+        return await knex.transaction(async (trx: any) => {
+            return await knex('report')
+                .transacting(trx)
+                .update(report)
+                .where('id', id)
+                .returning('*')
+                .then(async (report: any) => {
+                    const { articleId } = report[0];
+
+                    reportResponse = report[0];
+                    reportResponse.images = [];
+
+                    if (args.files[0]) {
+                        await knex('image').transacting(trx).where('report_id', id).del();
+
+                        files.forEach(async (file: any, idx: Number) => {
+                            const { createReadStream, mimetype } = await file;
+                            const stream = createReadStream();
+
+                            const filename =
+                                articleId + '_' + id + '_' + idx + '_' + Date.now() + '.' + mimetype.split('/')[1];
+
+                            const imageForm = {
+                                reportId: id,
+                                url: 'https://www.agaein.com/file/image/' + filename,
+                            };
+
+                            reportResponse.images.push(imageForm.url);
+
+                            await knex('image').transacting(trx).insert(imageForm);
+
+                            const out = require('fs').createWriteStream('image/' + filename);
+                            await stream.pipe(out);
+                            await stream.on('close', () => {
+                                console.log(`store ${filename}`);
+                            });
+                        });
+                    }
                 })
                 .then(() => {
                     return reportResponse;

--- a/agaein_server/graphql/typedefs/Report.graphql
+++ b/agaein_server/graphql/typedefs/Report.graphql
@@ -18,3 +18,10 @@ input reportInput {
     location: LocationInput!
     foundDate: Date!
 }
+
+input updateReportInput {
+    phoneNumber: String
+    content: String
+    location: LocationInput
+    foundDate: Date
+}

--- a/agaein_server/graphql/typedefs/index.graphql
+++ b/agaein_server/graphql/typedefs/index.graphql
@@ -27,9 +27,10 @@ type Mutation {
     login(kakaoId: String!): Login!
     # Article
     createArticle(boardType: BOARD_TYPE!, files: [Upload]!, articleDetail: articleDetailInput!): Article!
-    updateArticle(articleId: ID!, files: [Upload]!, articleDetail: articleDetailInput!): Article!
+    updateArticle(id: ID!, files: [Upload]!, articleDetail: articleDetailInput!): Article!
     deleteArticle(id: ID!, password: String): ID!
     createComment(articleId: ID!, commentId: ID, content: String!, password: String): Comment!
+    updateComment(id: ID!, content: String!, password: String): Comment!
     deleteComment(id: ID!, password: String): ID!
     # Breed
     createBreed(type: BREED_TYPE!, breed: String!): Breed!
@@ -39,4 +40,5 @@ type Mutation {
     deleteBookmark(id: ID!): ID!
     # Report
     createReport(files: [Upload]!, report: reportInput!): Report!
+    updateReport(id: ID!, files: [Upload]!, report: updateReportInput!): Report!
 }


### PR DESCRIPTION
## 작업 내용

* report & comment update 작성
* updateArticle에서 articleId를 받는 것을 id로 받는 것으로 변경 (article이 이미 명시되어 있기 때문 - 다른 쿼리들과 같게끔)

## 질문 사항

* 발견제보부분에 패스워드가 없으면 바로 생성이나 수정인데, 피그마 상에는 패스워드가 없었습니다. 이 부분 무조건 회원만 가능한건가요? - @Ting97ok @Haeeeun @hojunin 

## 참고 사항

* 이젠 기술부채를 챙길 것인가(리팩토링), 아니면 크롤링으로 먼저 넘어갈 것인가를 결정해야할 것 같아요. (수정하거나 CRUD 만들 것은 새로 생기는 대로 계속 만들면서)

