### PR TITLE
댓글 작성 로직 수정 및 일요일 회의내용 반영

### DIFF
--- a/agaein_web/src/components/molecules/ImageCarousel/ImageCarousel.tsx
+++ b/agaein_web/src/components/molecules/ImageCarousel/ImageCarousel.tsx
@@ -22,13 +22,8 @@ const ImageCarousel = (props: ImageCarouselProps) => {
             </FocusedImageWrapper>
             <CarouselList>
                 {images.map((img, index) => (
-                    <SmallImgWrapper>
-                        <SmallImg
-                            key={index.toString()}
-                            src={img}
-                            active={index === active}
-                            onClick={() => setActive(index)}
-                        />
+                    <SmallImgWrapper key={index.toString()}>
+                        <SmallImg src={img} active={index === active} onClick={() => setActive(index)} />
                     </SmallImgWrapper>
                 ))}
             </CarouselList>

--- a/agaein_web/src/components/organism/Comment/Comment.style.ts
+++ b/agaein_web/src/components/organism/Comment/Comment.style.ts
@@ -15,29 +15,6 @@ export const CommentContainer = styled.div`
 export const CommentHeader = styled.div`
     border-bottom: 1px solid #eee;
 `;
-
-// ? 어림잡아 맞춘 부분이라 좋은 방법이 있으면 수정해야함.
-export const CommentInputContainer = styled.div`
-    padding: 30px 30px 30px 30px;
-`;
-
-export const CommentToolContainer = styled.div`
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-`;
-
-export const CommentPwdContainer = styled.div`
-    display: flex;
-    align-items: center;
-    margin-top: 10px;
-    width: 435px;
-`;
-export const CommentPwd = styled(Input)`
-    width: 120px;
-    margin-right: 10px;
-`;
-
 export const DeleteModal = styled.div`
     width: 460px;
     margin: 0 auto;

--- a/agaein_web/src/components/organism/Comment/Comment.tsx
+++ b/agaein_web/src/components/organism/Comment/Comment.tsx
@@ -22,6 +22,7 @@ const Comment = (props: CommentProps) => {
     const [targetCommentId, setTargetCommentId] = useState<string | undefined>(undefined);
     const [submitButtonMode, setSubmitButtonMode] = useState<SUBMIT_MODE>('create');
     const [password] = useState<string | undefined>(undefined);
+    const [editCommentInput, setEditCommentInput] = useState<string | undefined>(undefined);
 
     const onPressSubmit = useCallback(
         (content: string, password?: string) => {
@@ -39,6 +40,7 @@ const Comment = (props: CommentProps) => {
                     content,
                     password,
                 });
+                setEditCommentInput(undefined);
             }
             setTargetCommentId(undefined);
         },
@@ -74,9 +76,11 @@ const Comment = (props: CommentProps) => {
         switch (key) {
             case '답글':
                 setSubmitButtonMode('create');
+                setEditCommentInput(undefined);
                 break;
             case '수정':
                 setSubmitButtonMode('edit');
+                setEditCommentInput(comments.find((comment) => comment.id === commentId)?.content);
                 break;
             case '삭제':
                 setIsModalOpened(true);
@@ -104,7 +108,11 @@ const Comment = (props: CommentProps) => {
                                 isAuthors={isAuthorComment(comment.author.kakaoId)}
                             />
                             {comment.id === targetCommentId && (
-                                <CommentInput ref={helperInputRef} onPressSubmit={onPressSubmit} />
+                                <CommentInput
+                                    ref={helperInputRef}
+                                    content={editCommentInput}
+                                    onPressSubmit={onPressSubmit}
+                                />
                             )}
                         </Fragment>
                     ))}

--- a/agaein_web/src/components/organism/Comment/CommentInput/CommentInput.style.ts
+++ b/agaein_web/src/components/organism/Comment/CommentInput/CommentInput.style.ts
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 
 export const CommentInputContainer = styled.div`
     position: relative;
-    margin: 30px 30px 30px 30px;
+    margin: 30px 30px 0px 30px;
 `;
 
 export const SubmitButton = styled.button`
@@ -22,12 +22,12 @@ export const CommentToolContainer = styled.div`
     display: flex;
     flex-direction: row;
     justify-content: space-between;
+    padding: 12px 0px 30px 30px;
 `;
 
 export const CommentPwdContainer = styled.div`
     display: flex;
     align-items: center;
-    margin-top: 10px;
     width: 435px;
 `;
 export const CommentPwd = styled(Input)`

--- a/agaein_web/src/components/organism/Comment/CommentInput/CommentInput.style.ts
+++ b/agaein_web/src/components/organism/Comment/CommentInput/CommentInput.style.ts
@@ -1,0 +1,36 @@
+import { Input } from 'components/molecules';
+import styled from 'styled-components';
+
+export const CommentInputContainer = styled.div`
+    position: relative;
+    margin: 30px 30px 30px 30px;
+`;
+
+export const SubmitButton = styled.button`
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 100px;
+    height: 100%;
+    background-color: ${(props) => (props.disabled ? props.theme.light.DarkGrey1 : props.theme.light.primary)};
+    color: ${(props) => props.theme.light.white};
+    font-weight: 400;
+    border-radius: 0px 4px 4px 0px;
+`;
+
+export const CommentToolContainer = styled.div`
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+`;
+
+export const CommentPwdContainer = styled.div`
+    display: flex;
+    align-items: center;
+    margin-top: 10px;
+    width: 435px;
+`;
+export const CommentPwd = styled(Input)`
+    width: 120px;
+    margin-right: 10px;
+`;

--- a/agaein_web/src/components/organism/Comment/CommentInput/CommentInput.tsx
+++ b/agaein_web/src/components/organism/Comment/CommentInput/CommentInput.tsx
@@ -1,7 +1,7 @@
 import { Textarea } from 'components/molecules';
 import { RequiredGuide, RequiredIcon } from 'components/organism/Form/Form.style';
 import { UserContext } from 'contexts/userContext';
-import React, { forwardRef, Fragment, InputHTMLAttributes, useCallback, useContext, useState } from 'react';
+import React, { forwardRef, Fragment, InputHTMLAttributes, useCallback, useContext, useEffect, useState } from 'react';
 import {
     CommentInputContainer,
     CommentPwd,
@@ -11,15 +11,20 @@ import {
 } from './CommentInput.style';
 
 export interface CommentInputProps extends InputHTMLAttributes<HTMLTextAreaElement> {
+    content?: string;
     commentId?: string;
     onPressSubmit: (content: string, password?: string) => void;
 }
 
 const CommentInput = forwardRef<HTMLTextAreaElement, CommentInputProps>((props, ref) => {
-    const { commentId, onPressSubmit, ...TextAreaProps } = props;
+    const { content = null, commentId, onPressSubmit, ...TextAreaProps } = props;
     const { isLoggedIn } = useContext(UserContext);
     const [commentInput, setCommentInput] = useState<string | undefined>('');
     const [password, setPassword] = useState<string | undefined>(undefined);
+
+    useEffect(() => {
+        setCommentInput(content ?? '');
+    }, [content]);
 
     // TODO : 비밀번호 규칙을 정해서 적용해야함.
     const onChangePwd = (pwd: string) => {
@@ -36,10 +41,17 @@ const CommentInput = forwardRef<HTMLTextAreaElement, CommentInputProps>((props, 
         setCommentInput(undefined);
         setPassword(undefined);
     };
+    const isCommentInput = useCallback(() => {
+        return commentInput === undefined || commentInput === '';
+    }, [commentInput]);
+
+    const isPassword = useCallback(() => {
+        return !isLoggedIn && (password === undefined || password.length < 4);
+    }, [isLoggedIn, password]);
 
     const submitDisabled = useCallback(() => {
-        return !commentInput || (!isLoggedIn && typeof password === 'string' && password.length !== 4);
-    }, [commentInput, isLoggedIn]);
+        return isCommentInput() || isPassword();
+    }, [isCommentInput, isPassword]);
 
     return (
         <Fragment>
@@ -61,6 +73,7 @@ const CommentInput = forwardRef<HTMLTextAreaElement, CommentInputProps>((props, 
                     <CommentPwdContainer>
                         <CommentPwd
                             type="password"
+                            maxLength={4}
                             value={password ?? ''}
                             onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                                 onChangePwd(e.target.value);

--- a/agaein_web/src/components/organism/Comment/CommentInput/CommentInput.tsx
+++ b/agaein_web/src/components/organism/Comment/CommentInput/CommentInput.tsx
@@ -1,0 +1,81 @@
+import { Textarea } from 'components/molecules';
+import { RequiredGuide, RequiredIcon } from 'components/organism/Form/Form.style';
+import { UserContext } from 'contexts/userContext';
+import React, { forwardRef, Fragment, InputHTMLAttributes, useCallback, useContext, useState } from 'react';
+import {
+    CommentInputContainer,
+    CommentPwd,
+    CommentPwdContainer,
+    CommentToolContainer,
+    SubmitButton,
+} from './CommentInput.style';
+
+export interface CommentInputProps extends InputHTMLAttributes<HTMLTextAreaElement> {
+    commentId?: string;
+    onPressSubmit: (content: string, password?: string) => void;
+}
+
+const CommentInput = forwardRef<HTMLTextAreaElement, CommentInputProps>((props, ref) => {
+    const { commentId, onPressSubmit, ...TextAreaProps } = props;
+    const { isLoggedIn } = useContext(UserContext);
+    const [commentInput, setCommentInput] = useState<string | undefined>('');
+    const [password, setPassword] = useState<string | undefined>(undefined);
+
+    // TODO : 비밀번호 규칙을 정해서 적용해야함.
+    const onChangePwd = (pwd: string) => {
+        if (pwd.length <= 4) {
+            setPassword(pwd);
+        }
+    };
+    const onClickSubmitButton = () => {
+        if (commentInput === undefined || (!isLoggedIn && password === undefined)) return;
+        onPressSubmit(commentInput, password);
+        resetCommentInput();
+    };
+    const resetCommentInput = () => {
+        setCommentInput(undefined);
+        setPassword(undefined);
+    };
+
+    const submitDisabled = useCallback(() => {
+        return !commentInput || (!isLoggedIn && typeof password === 'string' && password.length !== 4);
+    }, [commentInput, isLoggedIn]);
+
+    return (
+        <Fragment>
+            <CommentInputContainer>
+                <Textarea
+                    {...TextAreaProps}
+                    ref={ref}
+                    value={commentInput ?? ''}
+                    style={{ padding: '14px 114px 14px 14px' }}
+                    onChange={(e) => setCommentInput(e.target.value)}
+                    placeholder="발견 정보 또는 응원의 메세지를 남겨주세요 :)"
+                />
+                <SubmitButton onClick={onClickSubmitButton} disabled={submitDisabled()}>
+                    등록
+                </SubmitButton>
+            </CommentInputContainer>
+            <CommentToolContainer>
+                {!isLoggedIn && (
+                    <CommentPwdContainer>
+                        <CommentPwd
+                            type="password"
+                            value={password ?? ''}
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                                onChangePwd(e.target.value);
+                            }}
+                            placeholder="비밀번호"
+                        />
+                        <RequiredGuide>
+                            <RequiredIcon />
+                            비회원의 경우 댓글 등록, 수정, 삭제에 비밀번호가 필요합니다.
+                        </RequiredGuide>
+                    </CommentPwdContainer>
+                )}
+            </CommentToolContainer>
+        </Fragment>
+    );
+});
+
+export default CommentInput;

--- a/agaein_web/src/components/organism/Comment/CommentInput/index.ts
+++ b/agaein_web/src/components/organism/Comment/CommentInput/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CommentInput';

--- a/agaein_web/src/components/organism/Comment/CommentItem/CommentItem.tsx
+++ b/agaein_web/src/components/organism/Comment/CommentItem/CommentItem.tsx
@@ -73,7 +73,13 @@ const CommentItem = (props: CommentItemProps) => {
                                         // TODO : 매우 비효율적. 다른 방법이 필요함.
                                         if (isMemberComment() && !isLoggedIn && label !== '답글') return <></>;
                                         return (
-                                            <SelectItem key={label} onClick={() => menuHandler(label, id)}>
+                                            <SelectItem
+                                                key={label}
+                                                onClick={() => {
+                                                    menuHandler(label, id);
+                                                    setSelectVisible(false);
+                                                }}
+                                            >
                                                 {label}
                                             </SelectItem>
                                         );

--- a/agaein_web/src/components/organism/ReactKakaoMap/ReactKakaoMap.tsx
+++ b/agaein_web/src/components/organism/ReactKakaoMap/ReactKakaoMap.tsx
@@ -22,7 +22,7 @@ interface ReactKakaoMapProps {
         roadAddress: string;
         address: string;
     };
-    foundPosition?: Array<Location>;
+    foundPosition?: Location[];
     listClickIdx?: number;
 }
 declare global {
@@ -38,7 +38,7 @@ const ReactKaKaoMap = (props: ReactKakaoMapProps) => {
         size = { width: 500, height: 500 },
         borderRadius = 5,
         missPosition,
-        foundPosition,
+        foundPosition = [],
         isCategory = false,
         noClick = false,
         listClickIdx,

--- a/agaein_web/src/components/pages/article/articleDetail/ArticleDetail.style.ts
+++ b/agaein_web/src/components/pages/article/articleDetail/ArticleDetail.style.ts
@@ -66,3 +66,14 @@ export const ArticleInfoContainer = styled.div`
 export const ArticleMapContainer = styled.div`
     padding: 20px 30px 30px;
 `;
+export const InfoHeader = styled.div`
+    display: flex;
+    margin-bottom: 10px;
+    justify-content: space-between;
+`;
+export const InfoHeaderFont = styled.span<{ panted?: boolean }>`
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 22px;
+    color: ${(props) => (props.panted ? props.theme.light.primary : props.theme.light.DarkGrey2)};
+`;

--- a/agaein_web/src/components/pages/article/articleList/ArticleList.tsx
+++ b/agaein_web/src/components/pages/article/articleList/ArticleList.tsx
@@ -1,8 +1,6 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useState } from 'react';
 import Font from 'components/molecules/Font';
 import {
-    ArticleGridContainer,
-    ArticleItem,
     ArticleListContainer,
     ArticleListFooter,
     ArticleListHeaderContainer,
@@ -13,46 +11,16 @@ import {
 } from './ArticleList.style';
 import { RouteComponentProps } from 'react-router';
 import { ArticleListParams } from 'router/params';
-import { Article, Board_Type, useGetArticlesLazyQuery } from 'graphql/generated/generated';
-import Button from 'components/molecules/Button';
-import Pagination from 'components/molecules/Pagination';
-import PostItemBox from 'components/molecules/PostItemBox';
-import ReviewItem from 'components/molecules/ReviewItem';
-import useBookmark from 'hooks/useBookmark';
+import { Board_Type } from 'graphql/generated/generated';
+import { Button, Input, Pagination } from 'components/molecules';
 import { getTitle } from 'utils/converter';
-import { ITEM_PER_PAGE } from '.';
-import Input from 'components/molecules/Input';
+import ContentsList from './ContentsList';
 
 // TODO : 페이지네이션 클릭 시마다 2회씩 렌더링되는 이슈, lazy query말고 pagination으로 해결할 방법을 생각해야 함
 const ArticleList = ({ history, match }: RouteComponentProps<ArticleListParams>) => {
     const { type } = match.params;
-    const { isBookmarked, setBookmark } = useBookmark();
     const [searchInput, setSearchInput] = useState<string | undefined>(undefined);
     const [page, setPage] = useState(1);
-    const [get, { data, loading, error }] = useGetArticlesLazyQuery();
-
-    const getArticles = useCallback(() => {
-        get({
-            variables: {
-                boardType: type,
-                limit: ITEM_PER_PAGE,
-                offset: (page - 1) * ITEM_PER_PAGE ?? 0,
-            },
-        });
-    }, [page]);
-
-    useEffect(() => {
-        getArticles();
-    }, [getArticles]);
-
-    if (loading || !data) {
-        return <Font label="잠시만 기다려주세요" fontType="h2" />;
-    }
-    if (error) {
-        return <Font label="에러가 발생했습니다" fontType="h2" />;
-    }
-    const articles = data?.articles as Article[];
-
     const goCreateArticlePage = () => {
         type === Board_Type.Review ? history.push('/review') : history.push(`/createArticle/step2/${type}`);
     };
@@ -73,22 +41,7 @@ const ArticleList = ({ history, match }: RouteComponentProps<ArticleListParams>)
                     </SearchButton>
                 </SearchBarContainer>
             </ArticleListHeaderContainer>
-            <ArticleGridContainer>
-                {articles.map((item) => (
-                    <ArticleItem type={type}>
-                        {type === Board_Type.Review ? (
-                            <ReviewItem key={item.id} item={item} />
-                        ) : (
-                            <PostItemBox
-                                key={item.id}
-                                item={item}
-                                bookmarked={isBookmarked(item.id)}
-                                setBookmark={() => setBookmark(item.id)}
-                            />
-                        )}
-                    </ArticleItem>
-                ))}
-            </ArticleGridContainer>
+            <ContentsList type={type} page={page} searchText={searchInput} />
             <ArticleListFooter>
                 <Button label="게시글 작성" buttonStyle="PAINTED" onClick={goCreateArticlePage} />
                 <Pagination active={page} setActive={setPage} />

--- a/agaein_web/src/components/pages/article/articleList/ContentsList.tsx
+++ b/agaein_web/src/components/pages/article/articleList/ContentsList.tsx
@@ -1,0 +1,60 @@
+import { useCallback, useEffect } from 'react';
+import { Font, PostItemBox, ReviewItem } from 'components/molecules';
+import { Article, Board_Type, useGetArticlesLazyQuery } from 'graphql/generated/generated';
+import useBookmark from 'hooks/useBookmark';
+import { ITEM_PER_PAGE } from '.';
+import { ArticleGridContainer, ArticleItem } from './ArticleList.style';
+
+interface ListProps {
+    type: Board_Type;
+    page: number;
+    searchText?: string;
+}
+
+const ContentsList = (props: ListProps) => {
+    const { type, page = 1, searchText = '' } = props;
+    const { isBookmarked, setBookmark } = useBookmark();
+    const [get, { data, loading, error }] = useGetArticlesLazyQuery();
+
+    const getArticles = useCallback(() => {
+        get({
+            variables: {
+                boardType: type,
+                limit: ITEM_PER_PAGE,
+                offset: (page - 1) * ITEM_PER_PAGE,
+            },
+        });
+    }, [page]);
+
+    useEffect(() => {
+        getArticles();
+    }, [getArticles]);
+
+    if (loading || !data) {
+        return <Font label="잠시만 기다려주세요" fontType="h2" />;
+    }
+    if (error) {
+        return <Font label="에러가 발생했습니다" fontType="h2" />;
+    }
+    const articles = data?.articles as Article[];
+    return (
+        <ArticleGridContainer>
+            {articles.map((item) => (
+                <ArticleItem type={type}>
+                    {type === Board_Type.Review ? (
+                        <ReviewItem key={item.id} item={item} />
+                    ) : (
+                        <PostItemBox
+                            key={item.id}
+                            item={item}
+                            bookmarked={isBookmarked(item.id)}
+                            setBookmark={() => setBookmark(item.id)}
+                        />
+                    )}
+                </ArticleItem>
+            ))}
+        </ArticleGridContainer>
+    );
+};
+
+export default ContentsList;

--- a/agaein_web/src/graphql/queries/Article.fragment.graphql
+++ b/agaein_web/src/graphql/queries/Article.fragment.graphql
@@ -43,9 +43,7 @@ fragment LFGDetail on LFG {
     email
     keyword
     location {
-        lat
-        lng
-        address
+        ...LocationFragment
     }
 }
 fragment LFPDetail on LFP {
@@ -61,14 +59,19 @@ fragment LFPDetail on LFP {
     email
     keyword
     location {
-        lat
-        lng
-        address
-        detail
+        ...LocationFragment
     }
 }
 fragment ReviewDetail on REVIEW {
     id
     title
     content
+}
+
+fragment LocationFragment on Location {
+    lat
+    lng
+    address
+    detail
+    roadAddress
 }

--- a/agaein_web/src/graphql/queries/Article.graphql
+++ b/agaein_web/src/graphql/queries/Article.graphql
@@ -22,6 +22,11 @@ query getArticle($id: ID!) {
     article(id: $id) {
         ...ArticleFragment
     }
+    reports(articleId: $id) {
+        location {
+            ...LocationFragment
+        }
+    }
 }
 
 mutation createArticle($boardType: BOARD_TYPE!, $files: [Upload]!, $articleDetail: articleDetailInput!) {

--- a/agaein_web/src/graphql/queries/report.graphql
+++ b/agaein_web/src/graphql/queries/report.graphql
@@ -1,7 +1,6 @@
 query getReports($articleId: ID!) {
     reports(articleId: $articleId) {
         id
-        articleId
         author {
             ...UserFragment
         }
@@ -9,15 +8,9 @@ query getReports($articleId: ID!) {
         phoneNumber
         content
         location {
-            lat
-            lng
-            address
-            roadAddress
-            detail
+            ...LocationFragment
         }
         foundDate
-        createdAt
-        updatedAt
     }
 }
 

--- a/agaein_web/src/utils/typeGuards.ts
+++ b/agaein_web/src/utils/typeGuards.ts
@@ -1,4 +1,4 @@
-import { Article, Bookmark, Comment, Lfg, Lfp, Review, ArticleDetailInput } from 'graphql/generated/generated';
+import { Article, Bookmark, Comment, Lfg, Lfp, Review, ArticleDetailInput, Report } from 'graphql/generated/generated';
 
 // TODO : Type Guard의 조건을 더 엄밀하게 정의해야함
 
@@ -24,6 +24,14 @@ function isComments(target: unknown[]): target is Comment[] {
     return (target as Comment[]).some((comment) => isComment(comment));
 }
 
+function isReport(target: unknown): target is Report {
+    return (target as Report).__typename === 'Report' && (target as Report).location !== null;
+}
+
+function isReports(target: unknown[]): target is Report[] {
+    return (target as Report[]).some((report) => isReport(report));
+}
+
 function isArticleDetail(target: unknown, dateType: 'lostDate' | 'foundDate'): target is ArticleDetailInput {
     return (
         !!(target as ArticleDetailInput).location?.address &&
@@ -32,4 +40,4 @@ function isArticleDetail(target: unknown, dateType: 'lostDate' | 'foundDate'): t
     );
 }
 
-export { isArticle, isComment, isLFP, isLFG, isReview, isBookmark, isComments, isArticleDetail };
+export { isArticle, isComment, isLFP, isLFG, isReview, isBookmark, isComments, isArticleDetail, isReports };


### PR DESCRIPTION
댓글 작성 로직 변경하고, 회의 때 나온 내용들 반영했습니다(게시글 리스트 리렌더링, 게시글 상세에 쿼리 추가 등)

## 작업 내용
* 댓글 입력창 디자인 변경 및 분리, 수정과 답글 시 바로 아래 뜨도록 변경
* 게시글 상세 쿼리 변경(reports 쿼리 추가)
* 게시글 리스트에서 컨텐츠 컴포넌트 분리(ContentList에서 쿼리를 날림)
## 참고 사항
* ArticleList.tsx에서 page라는 state를 가지고 있어야 해서 아직 페이지 전체 리렌더링을 막지는 못합니다. (ref를 쓰는 방법도 있긴 함..)
급한 이슈 아니니 나중에 완성도 높일 때 고쳐보겠습니다.
* 댓글 삭제를 누르면 수정이나 답글때처럼 해당 댓글 아래로 CommentInput 컴포넌트가 생기는 이슈는, 좋은 방법이 안떠올라서 아직 수정하지 않았습니다.  