### PR TITLE
랜덤 닉네임, 게시물 정렬 방식, 발견제보 비밀번호 기능 추가

### DIFF
--- a/agaein_server/common/utils/nickname.ts
+++ b/agaein_server/common/utils/nickname.ts
@@ -1,0 +1,39 @@
+export function getRandomNickname() {
+    const number = new Date().getMilliseconds() % 15;
+
+    const adjective = [
+        '작은',
+        '거대한',
+        '꾸안꾸',
+        '마지막에 남은',
+        '홀로선',
+        '외로운',
+        '구걸하는',
+        '규칙없는',
+        '날아다니는',
+        '굴러다니는',
+        '미움받는',
+        '걱정하는',
+        '폰만 보는',
+        '사랑받는',
+        '노래하는',
+    ];
+    const noun = [
+        '허수아비',
+        '발바닥',
+        '노루',
+        '부엉이',
+        '치타',
+        '강아지',
+        '얼룩말',
+        '임금님',
+        '박쥐',
+        '망둥어',
+        '잉어',
+        '자라',
+        '백댄서',
+        '가수',
+        '배우',
+    ];
+    return adjective[number] + " " + noun[number];
+}

--- a/agaein_server/graphql/database.ts
+++ b/agaein_server/graphql/database.ts
@@ -355,6 +355,7 @@ export function initReport() {
                         .onDelete('CASCADE');
                     table.string('phone_number');
                     table.string('content');
+                    table.string('password');
                     table.json('location').notNullable().defaultTo({});
                     table.dateTime('found_date').notNullable();
                     table.dateTime('created_at').notNullable();

--- a/agaein_server/graphql/resolvers/article/queries.ts
+++ b/agaein_server/graphql/resolvers/article/queries.ts
@@ -3,22 +3,55 @@ import { knex } from '../../database';
 
 const articleQueries = {
     articles: async (_: any, args: any) => {
-        const { boardType, limit = 6, offset = 0 } = args;
+        const { boardType, limit = 6, offset = 0, order = 'new' } = args;
         try {
-            const articleDetails =
-                boardType === 'REVIEW'
-                    ? await knex(`${boardType}`)
-                          .join('article', 'article.id', `${boardType}.article_id`)
-                          .orderBy('created_at', 'desc')
-                          .limit(limit)
-                          .offset(offset)
-                    : await knex(`${boardType}`)
-                          .join('article', 'article.id', `${boardType}.article_id`)
-                          .join('breed', `${boardType}.breed_id`, 'breed.id')
-                          .select('*', `${boardType}.id as id`)
-                          .orderBy('created_at', 'desc')
-                          .limit(limit)
-                          .offset(offset);
+            let articleDetails;
+            if (order === 'new') {
+                articleDetails =
+                    boardType === 'REVIEW'
+                        ? await knex(`${boardType}`)
+                              .join('article', 'article.id', `${boardType}.article_id`)
+                              .orderBy('created_at', 'desc')
+                              .limit(limit)
+                              .offset(offset)
+                        : await knex(`${boardType}`)
+                              .join('article', 'article.id', `${boardType}.article_id`)
+                              .join('breed', `${boardType}.breed_id`, 'breed.id')
+                              .select('*', `${boardType}.id as id`)
+                              .orderBy('created_at', 'desc')
+                              .limit(limit)
+                              .offset(offset);
+            } else if (order === "old") {
+                articleDetails =
+                    boardType === 'REVIEW'
+                        ? await knex(`${boardType}`)
+                              .join('article', 'article.id', `${boardType}.article_id`)
+                              .orderBy('created_at', 'asc')
+                              .limit(limit)
+                              .offset(offset)
+                        : await knex(`${boardType}`)
+                              .join('article', 'article.id', `${boardType}.article_id`)
+                              .join('breed', `${boardType}.breed_id`, 'breed.id')
+                              .select('*', `${boardType}.id as id`)
+                              .orderBy('created_at', 'asc')
+                              .limit(limit)
+                              .offset(offset);
+            } else {
+                articleDetails =
+                    boardType === 'REVIEW'
+                        ? await knex(`${boardType}`)
+                              .join('article', 'article.id', `${boardType}.article_id`)
+                              .orderBy('view', 'desc')
+                              .limit(limit)
+                              .offset(offset)
+                        : await knex(`${boardType}`)
+                              .join('article', 'article.id', `${boardType}.article_id`)
+                              .join('breed', `${boardType}.breed_id`, 'breed.id')
+                              .select('*', `${boardType}.id as id`)
+                              .orderBy('view', 'desc')
+                              .limit(limit)
+                              .offset(offset);
+            }
 
             const articles = articleDetails.map((detail: any) => {
                 const { articleId, breedId, keyword, ...detailData } = detail;

--- a/agaein_server/graphql/resolvers/user/mutations.ts
+++ b/agaein_server/graphql/resolvers/user/mutations.ts
@@ -1,5 +1,6 @@
 import { ApolloError } from 'apollo-server-errors';
 import { isValidatedLogin } from '../../../common/validation/user';
+import { getRandomNickname } from '../../../common/utils/nickname';
 import { getAccessToken, getRefreshToken } from '../../../common/auth/jwtToken';
 import { knex } from '../../database';
 
@@ -24,6 +25,7 @@ const userMutations = {
                 kakao_id: args.kakaoId,
                 created_at: now,
                 updated_at: now,
+                nickname: getRandomNickname(),
             };
 
             user = await knex('user').insert(userForm).returning('*');

--- a/agaein_server/graphql/typedefs/Article.graphql
+++ b/agaein_server/graphql/typedefs/Article.graphql
@@ -10,6 +10,12 @@ enum GENDER {
     unknown
 }
 
+enum ARTICLE_ORDER {
+    new
+    old
+    view
+}
+
 type Location {
     lat: Float!
     lng: Float!
@@ -26,7 +32,6 @@ type LFG {
     feature: String
     gender: GENDER
     age: Int
-    password: String
     alarm: Boolean
     email: String
     keyword: [String]
@@ -43,7 +48,6 @@ type LFP {
     gender: GENDER
     gratuity: Int
     age: Int
-    password: String
     alarm: Boolean
     email: String
     keyword: [String]

--- a/agaein_server/graphql/typedefs/Report.graphql
+++ b/agaein_server/graphql/typedefs/Report.graphql
@@ -17,6 +17,7 @@ input reportInput {
     content: String
     location: LocationInput!
     foundDate: Date!
+    password: String
 }
 
 input updateReportInput {
@@ -24,4 +25,5 @@ input updateReportInput {
     content: String
     location: LocationInput
     foundDate: Date
+    password: String
 }

--- a/agaein_server/graphql/typedefs/comment.graphql
+++ b/agaein_server/graphql/typedefs/comment.graphql
@@ -2,7 +2,6 @@ type Comment implements Timestamps {
     id: ID!
     content: String!
     reply: [Comment]!
-    password: String
     author: User!
     createdAt: Date!
     updatedAt: Date!

--- a/agaein_server/graphql/typedefs/index.graphql
+++ b/agaein_server/graphql/typedefs/index.graphql
@@ -13,7 +13,7 @@ type Query {
     user(id: ID!): User
     me: User!
     # Article
-    articles(boardType: BOARD_TYPE!, offset: Int, limit: Int): [Article]!
+    articles(boardType: BOARD_TYPE!, offset: Int, limit: Int, order: ARTICLE_ORDER): [Article]!
     article(id: ID!): Article
     articleLength(boardType: BOARD_TYPE!): Int!
     # Breed
@@ -42,5 +42,5 @@ type Mutation {
     # Report
     createReport(files: [Upload]!, report: reportInput!): Report!
     updateReport(id: ID!, files: [Upload]!, report: updateReportInput!): Report!
-    deleteReport(id: ID!): ID!
+    deleteReport(id: ID!, password: String): ID!
 }


### PR DESCRIPTION
## 작업 내용

* report password 추가
  * 추가 중에 password는 반환되면 안 되는 값인데 다른 article이나 comment에 반환되고 있는 것을 확인 - 삭제했습니다.
* article 정렬 방식 enum형식으로 3가지 추가 - new, old, view
* 이제 새로 가입하면 랜덤 닉네임이 주어집니다.

## 참고 사항

* @hojunin 코드젠 연동 부탁드립니다.
* @Haeeeun @Ting97ok 서버에 위의 기능 추가되었습니다. 참고하세요!
